### PR TITLE
Add /etc/build into the image.

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -89,4 +89,12 @@ OPTEE_TA_SIGN_KEY ??= "${TOPDIR}/conf/keys/opteedev.key"
 UEFI_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys/uefi"
 #UEFI_SIGN_ENABLE ?= "1"
 
+# Izuma additions
+#
+
+# Accept EULA for building imx8mmevk target.
 ACCEPT_FSL_EULA = "1"
+
+# Add /etc/build into the image
+INHERIT += "image-buildinfo"
+


### PR DESCRIPTION
INHERITS "image-buildinfo" which then auto-creates the /etc/build file containing information about the layers.