### PR TITLE
Fix meta-edge hash to current tip of master

### DIFF
--- a/edge.xml
+++ b/edge.xml
@@ -7,6 +7,6 @@
   <project name="meta-edge"
            path="layers/meta-edge"
            remote="PelionIoT"
-           revision="main" />
+           revision="11a8ab668c6a8c295271f6dcd51336bd976b3a97" />
 
 </manifest>


### PR DESCRIPTION
We should not use just "main" as it floats, we must fix it a specific, known hash (for releases at least). 
- Current tip of master is what the 2.6.0 will be based on.

Change-Id: Ifdfb754c1852443adc6743332c20d134587f9359