### PR TITLE
Update to LmP v92

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
 		make patch repo sudo texinfo vim-tiny wget whiptail libelf-dev git-lfs screen \
 		socket corkscrew curl xz-utils tcl libtinfo5 device-tree-compiler python3-pip python3-dev \
 		tmux libncurses-dev vim zstd lz4 liblz4-tool libc6-dev-i386 \
-		awscli docker-compose gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon \
+		awscli docker-compose gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon tree rsync \
 	&& ln -s /usr/bin/python3 /usr/bin/python \
 	&& pip3 --no-cache-dir install expandvars jsonFormatter \
 	&& apt-get autoremove -y \

--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -18,6 +18,7 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-xilinx-tools \
   ${OEROOT}/layers/meta-tegra \
   ${OEROOT}/layers/meta-ti/meta-ti-bsp \
+  ${OEROOT}/layers/meta-ti/meta-ti-extras \
   ${OEROOT}/layers/meta-st-stm32mp \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -101,6 +101,15 @@ UEFI_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys/uefi"
 UEFI_SIGN_KEYDIR[vardepsexclude] += "TOPDIR"
 #UEFI_SIGN_ENABLE ?= "1"
 
+#
+# STM32CubeProgrammer STM32MP Signing Tool configuration
+#
+#STM32_ROT_SIGN_ENABLE ??= "1"
+#STM32_CUBE_PATH ??= "/usr/local/STMicroelectronics/STM32Cube/STM32CubeProgrammer"
+STM32_ROT_KEY_PATH ??= "${TOPDIR}/../tools/lmp-tools/security/stm32mp1/"
+STM32_ROT_KEY_PATH[vardepsexclude] += "TOPDIR"
+STM32_ROT_KEY_PASSWORD ??= "foundries"
+
 # Izuma additions
 #
 

--- a/edge.xml
+++ b/edge.xml
@@ -7,5 +7,5 @@
   <project name="meta-edge"
            path="layers/meta-edge"
            remote="PelionIoT"
-           revision="a933716daa59fb25d6aa2f542691ca6017953a0a" />
+           revision="16ead059870aef403ae402e5efc4340efb5184a9" />
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,17 +5,17 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="0c6f86b60cfba67c20733516957c0a654eb2b44c"/>
+  <project name="bitbake" revision="42a1c9fe698a03feb34c5bba223c6e6e0350925b"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="63898f5049acb325d3ee27fd016b9f1d01f74092"/>
-  <project name="meta-clang" path="layers/meta-clang" revision="35231498962d0f3e75866c7e20ae6b2f87a2ae28"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="a82d92c8a6525da01524bf8f4a60bf6b35dcbb3d"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="315d2d288fdcd2768f189101d980f40b0f2c9b0d"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="feed1bb0eb4aefb701d582156d7defb0c1fc0473"/>
-  <project name="meta-security" path="layers/meta-security" revision="d398cc6ea6716afd3a3a6e88ad8fbdc89510ef23"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="be1217764c926e46acdaf9e8d1fa6404090723f5"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="a7413c5d7568ce91b809ed11f84305b1afb468bb"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="f20a12ead2d5890e88e7f4ce149a777de47edc48"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c960c0a67c18b4024567ed9018d52ca7400a76a2"/>
+  <project name="meta-clang" path="layers/meta-clang" revision="79169d9be565b7a87310ca280d3a21aaf608ce33"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="402affcc073db39f782c1ebfd718edd5f11eed4c"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="a0384aea22a3ddfc70202a26ee1372c91b1fcfc9"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="6b3a208f7e14138728a6e581ac75e8973ab48ef3"/>
+  <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="9f7fe77932671751f3c7201d164ffbabd0cb2faf"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="478a91800c4a95c7410dc8ef52e229a81be24b4e"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="2afd9a6002cba2a23dd62a1805b4be04083c041b"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,14 +6,14 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="a4fa050975779d84f4b30f825597fd4d83ac3482"/>
-  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="a9bff0e2ce1384c17b43c948745fb0556733ae26"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="1edf26e5b90371c9acf7bd6ac7155000de85f133"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="0a73d1bdd7713a6189482e463c98043c9939a2a2"/>
+  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="7725256e3859b62f1ff201db7f2cf7026c17656d"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="f932ebb2544170f43edd22739f44307809bf8cfb"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="43683cb14b6afc144619335b3a2353b70762ff3e"/>
-  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="ca501bd7dbe023682903ceedddaacd940b0898f4"/>
-  <project name="meta-yocto" path="layers/meta-yocto" revision="c0435b61978e431974628a052ce2812fbd8e7196"/>
+  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="6d84bde08c03ec0184af08c2d3875fe5a334587e"/>
+  <project name="meta-yocto" path="layers/meta-yocto" revision="77c2830ae0c3e7370f7c816796981932ba0ec99a"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="f8d8efab12040712df32436643621b2756de1f76"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="48b6a1454caa4f17862bd185d5f08e00f1aed629"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="522370739fe8f1c9a5e7eeb50a0832140a95291d"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="30cdeef2e8c7d0dfa6b5c4bb929636ee02ae347a"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="c3916324a01fe96c68a78ef9ed0070d6b1fc8f2f"/>
 </manifest>

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -160,39 +160,42 @@ sha512sum "${MANIFESTS}"/setup-environment-internal 2>&1 > conf/checksum
 if [ ! -f "conf/local.conf" ]; then
     cp "${MANIFESTS}"/conf/local.conf conf/local.conf
 fi
+
 # Copy default development keys if not set by the user
-mkdir -p conf/keys
-if [ ! -f "conf/keys/dev.key" -a ! -f "conf/keys/dev.crt" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/dev.key conf/keys/dev.key
-    ln -sf "${MANIFESTS}"/conf/keys/dev.crt conf/keys/dev.crt
-fi
-# Copy default SPL development keys if not set by the user
-if [ ! -f "conf/keys/spldev.key" -a ! -f "conf/keys/spldev.crt" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/spldev.key conf/keys/spldev.key
-    ln -sf "${MANIFESTS}"/conf/keys/spldev.crt conf/keys/spldev.crt
-fi
-# Copy default u-boot development keys if not set by the user
-if [ ! -f "conf/keys/ubootdev.key" -a ! -f "conf/keys/ubootdev.crt" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/ubootdev.key conf/keys/ubootdev.key
-    ln -sf "${MANIFESTS}"/conf/keys/ubootdev.crt conf/keys/ubootdev.crt
-fi
-# Copy default optee development keys if not set by the user
-if [ ! -f "conf/keys/opteedev.key" -a ! -f "conf/keys/opteedev.crt" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/opteedev.key conf/keys/opteedev.key
-    ln -sf "${MANIFESTS}"/conf/keys/opteedev.crt conf/keys/opteedev.crt
-fi
-# Copy default module kernel development keys if not set by the user
-if [ ! -f "conf/keys/privkey_modsign.pem" -a ! -f "conf/keys/x509_modsign.crt" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/privkey_modsign.pem conf/keys/privkey_modsign.pem
-    ln -sf "${MANIFESTS}"/conf/keys/x509_modsign.crt conf/keys/x509_modsign.crt
-fi
-# Link default TF-A development keys if not set by the user
-if [ ! -d "conf/keys/tf-a" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/tf-a conf/keys/tf-a
-fi
-# Link default UEFI development keys and certificates if not set by the user
-if [ ! -d "conf/keys/uefi" ]; then
-    ln -sf "${MANIFESTS}"/conf/keys/uefi conf/keys/uefi
+if [ -d "${MANIFESTS}"/conf/keys ]; then
+    mkdir -p conf/keys
+    if [ ! -f "conf/keys/dev.key" -a ! -f "conf/keys/dev.crt" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/dev.key conf/keys/dev.key
+        ln -sf "${MANIFESTS}"/conf/keys/dev.crt conf/keys/dev.crt
+    fi
+    # Copy default SPL development keys if not set by the user
+    if [ ! -f "conf/keys/spldev.key" -a ! -f "conf/keys/spldev.crt" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/spldev.key conf/keys/spldev.key
+        ln -sf "${MANIFESTS}"/conf/keys/spldev.crt conf/keys/spldev.crt
+    fi
+    # Copy default u-boot development keys if not set by the user
+    if [ ! -f "conf/keys/ubootdev.key" -a ! -f "conf/keys/ubootdev.crt" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/ubootdev.key conf/keys/ubootdev.key
+        ln -sf "${MANIFESTS}"/conf/keys/ubootdev.crt conf/keys/ubootdev.crt
+    fi
+    # Copy default optee development keys if not set by the user
+    if [ ! -f "conf/keys/opteedev.key" -a ! -f "conf/keys/opteedev.crt" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/opteedev.key conf/keys/opteedev.key
+        ln -sf "${MANIFESTS}"/conf/keys/opteedev.crt conf/keys/opteedev.crt
+    fi
+    # Copy default module kernel development keys if not set by the user
+    if [ ! -f "conf/keys/privkey_modsign.pem" -a ! -f "conf/keys/x509_modsign.crt" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/privkey_modsign.pem conf/keys/privkey_modsign.pem
+        ln -sf "${MANIFESTS}"/conf/keys/x509_modsign.crt conf/keys/x509_modsign.crt
+    fi
+    # Link default TF-A development keys if not set by the user
+    if [ ! -d "conf/keys/tf-a" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/tf-a conf/keys/tf-a
+    fi
+    # Link default UEFI development keys and certificates if not set by the user
+    if [ ! -d "conf/keys/uefi" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/uefi conf/keys/uefi
+    fi
 fi
 
 # Factory specific keys (unique per factory)
@@ -411,10 +414,17 @@ Some common targets are:
 EOF
 
 if [ "${DISTRO}" = 'lmp-mfgtool' ]; then
+    if [[ "${MACHINE}" == *"stm32mp1"* ]]; then
+        cat <<EOF
+    stm32-mfgtool-files           - MFGTOOL Support Files and Binaries for board flashing and provisioning (STM32MP1 machines)
+
+EOF
+    else
         cat <<EOF
     mfgtool-files           - MFGTOOL Support Files and Binaries for board flashing and provisioning
 
 EOF
+    fi
 else
 
         cat <<EOF


### PR DESCRIPTION
Copied files from LmP v92 release tag in https://github.com/foundriesio/lmp-manifest

Updated to use the meta-edge hash for v92.

Instructions for moving to a newer release of LmP are in https://izumanetworks.atlassian.net/wiki/spaces/IZUMA/pages/83656711/Updating+the+LmP+release+in+manifest-edge