### PR TITLE
Update to LmP v93

### DIFF
--- a/edge.xml
+++ b/edge.xml
@@ -7,5 +7,5 @@
   <project name="meta-edge"
            path="layers/meta-edge"
            remote="PelionIoT"
-           revision="16ead059870aef403ae402e5efc4340efb5184a9" />
+           revision="21cda8b27d74703e9ec7b2c6b178419fb979138c" />
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,17 +5,17 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="42a1c9fe698a03feb34c5bba223c6e6e0350925b"/>
+  <project name="bitbake" revision="ee090484cc25d760b8c20f18add17b5eff485b40"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c960c0a67c18b4024567ed9018d52ca7400a76a2"/>
-  <project name="meta-clang" path="layers/meta-clang" revision="79169d9be565b7a87310ca280d3a21aaf608ce33"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="402affcc073db39f782c1ebfd718edd5f11eed4c"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="a0384aea22a3ddfc70202a26ee1372c91b1fcfc9"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="6b3a208f7e14138728a6e581ac75e8973ab48ef3"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1be292cf3484f1a9fb4d7bea3c61cf45cd318264"/>
+  <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="8609de00952d65bb813a48c535c937324efeb18a"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="ab095f7f1ed2615cf8533f4657e9f7f176dfb4de"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="ead509ebe28cb9b588d401c5f254159cd6c5d39a"/>
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="9f7fe77932671751f3c7201d164ffbabd0cb2faf"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="478a91800c4a95c7410dc8ef52e229a81be24b4e"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="2afd9a6002cba2a23dd62a1805b4be04083c041b"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="3473dc7c88a16cea2e9a6365e22c2331464078f1"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="88327090d26955a678c6f8bd2585aad4d802f6c4"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="59cc2e75c15f8c6371a4c4a3b7bd2e6c3f145fbc"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,15 +5,15 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="meta-arm" path="layers/meta-arm" revision="96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd"/>
+  <project name="meta-arm" path="layers/meta-arm" revision="b187fb9232ca0a6b5f8f90b4715958546fc41d73"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="0a73d1bdd7713a6189482e463c98043c9939a2a2"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="7725256e3859b62f1ff201db7f2cf7026c17656d"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="f932ebb2544170f43edd22739f44307809bf8cfb"/>
-  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="43683cb14b6afc144619335b3a2353b70762ff3e"/>
-  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="6d84bde08c03ec0184af08c2d3875fe5a334587e"/>
-  <project name="meta-yocto" path="layers/meta-yocto" revision="77c2830ae0c3e7370f7c816796981932ba0ec99a"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
+  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
+  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="b0af85c466d96d5f794b125b2542b7a0ea4c91de"/>
+  <project name="meta-yocto" path="layers/meta-yocto" revision="fa70fbb1ebf2a712eebc5b154ce6d754324fb6ef"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="f8d8efab12040712df32436643621b2756de1f76"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="30cdeef2e8c7d0dfa6b5c4bb929636ee02ae347a"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="c3916324a01fe96c68a78ef9ed0070d6b1fc8f2f"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="b7a0792b996b47305c7ec1713621b0e07d314700"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="155218f03ee8222eeb02f11ea9bc41135cf28e38"/>
 </manifest>

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -147,7 +147,7 @@ if [ -f "conf/auto.conf" ]; then
              sed -e 's%^MACHINE ?= %%' | sed -e 's/^"//' -e 's/"$//')
 fi
 
-if [ -e conf/checksum -a "${MACHINE}" = "$oldmach" ]; then
+if [ -e conf/checksum ] && [ "${MACHINE}" = "$oldmach" ]; then
     sha512sum --quiet -c conf/checksum > /dev/null 2>&1
     if [ $? -eq 0 ]; then
        return
@@ -164,27 +164,27 @@ fi
 # Copy default development keys if not set by the user
 if [ -d "${MANIFESTS}"/conf/keys ]; then
     mkdir -p conf/keys
-    if [ ! -f "conf/keys/dev.key" -a ! -f "conf/keys/dev.crt" ]; then
+    if [ ! -f "conf/keys/dev.key" ] && [ ! -f "conf/keys/dev.crt" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/dev.key conf/keys/dev.key
         ln -sf "${MANIFESTS}"/conf/keys/dev.crt conf/keys/dev.crt
     fi
     # Copy default SPL development keys if not set by the user
-    if [ ! -f "conf/keys/spldev.key" -a ! -f "conf/keys/spldev.crt" ]; then
+    if [ ! -f "conf/keys/spldev.key" ] && [ ! -f "conf/keys/spldev.crt" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/spldev.key conf/keys/spldev.key
         ln -sf "${MANIFESTS}"/conf/keys/spldev.crt conf/keys/spldev.crt
     fi
     # Copy default u-boot development keys if not set by the user
-    if [ ! -f "conf/keys/ubootdev.key" -a ! -f "conf/keys/ubootdev.crt" ]; then
+    if [ ! -f "conf/keys/ubootdev.key" ] && [ ! -f "conf/keys/ubootdev.crt" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/ubootdev.key conf/keys/ubootdev.key
         ln -sf "${MANIFESTS}"/conf/keys/ubootdev.crt conf/keys/ubootdev.crt
     fi
     # Copy default optee development keys if not set by the user
-    if [ ! -f "conf/keys/opteedev.key" -a ! -f "conf/keys/opteedev.crt" ]; then
+    if [ ! -f "conf/keys/opteedev.key" ] && [ ! -f "conf/keys/opteedev.crt" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/opteedev.key conf/keys/opteedev.key
         ln -sf "${MANIFESTS}"/conf/keys/opteedev.crt conf/keys/opteedev.crt
     fi
     # Copy default module kernel development keys if not set by the user
-    if [ ! -f "conf/keys/privkey_modsign.pem" -a ! -f "conf/keys/x509_modsign.crt" ]; then
+    if [ ! -f "conf/keys/privkey_modsign.pem" ] && [ ! -f "conf/keys/x509_modsign.crt" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/privkey_modsign.pem conf/keys/privkey_modsign.pem
         ln -sf "${MANIFESTS}"/conf/keys/x509_modsign.crt conf/keys/x509_modsign.crt
     fi
@@ -196,45 +196,49 @@ if [ -d "${MANIFESTS}"/conf/keys ]; then
     if [ ! -d "conf/keys/uefi" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/uefi conf/keys/uefi
     fi
+    # Link default TI K3 RoT keys if not set by the user
+    if [ ! -d "conf/keys/platform" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/platform conf/keys/platform
+    fi
 fi
 
 # Factory specific keys (unique per factory)
 if [ -d "${MANIFESTS}"/factory-keys ]; then
     mkdir -p conf/factory-keys
     # Copy default factory SPL development keys if not set by the user
-    if [ ! -f "conf/factory-keys/spldev.key" -a ! -f "conf/factory-keys/spldev.crt" ]; then
+    if [ ! -f "conf/factory-keys/spldev.key" ] && [ ! -f "conf/factory-keys/spldev.crt" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/spldev.key conf/factory-keys/spldev.key
         ln -sf "${MANIFESTS}"/factory-keys/spldev.crt conf/factory-keys/spldev.crt
     fi
     # Copy default factory u-boot development keys if not set by the user
-    if [ ! -f "conf/factory-keys/ubootdev.key" -a ! -f "conf/factory-keys/ubootdev.crt" ]; then
+    if [ ! -f "conf/factory-keys/ubootdev.key" ] && [ ! -f "conf/factory-keys/ubootdev.crt" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/ubootdev.key conf/factory-keys/ubootdev.key
         ln -sf "${MANIFESTS}"/factory-keys/ubootdev.crt conf/factory-keys/ubootdev.crt
     fi
     # Copy default factory optee development keys if not set by the user
-    if [ ! -f "conf/factory-keys/opteedev.key" -a ! -f "conf/factory-keys/opteedev.crt" ]; then
+    if [ ! -f "conf/factory-keys/opteedev.key" ] && [ ! -f "conf/factory-keys/opteedev.crt" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/opteedev.key conf/factory-keys/opteedev.key
         ln -sf "${MANIFESTS}"/factory-keys/opteedev.crt conf/factory-keys/opteedev.crt
     fi
     # Copy default factory module kernel development keys if not set by the user
-    if [ ! -f "conf/factory-keys/privkey_modsign.pem" -a ! -f "conf/factory-keys/x509_modsign.crt" ]; then
+    if [ ! -f "conf/factory-keys/privkey_modsign.pem" ] && [ ! -f "conf/factory-keys/x509_modsign.crt" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/privkey_modsign.pem conf/factory-keys/privkey_modsign.pem
         ln -sf "${MANIFESTS}"/factory-keys/x509_modsign.crt conf/factory-keys/x509_modsign.crt
     fi
     # Link custom TF-A development keys set by the user
-    if [ -d "${MANIFESTS}"/factory-keys/tf-a -a ! -d "conf/factory-keys/tf-a" ]; then
+    if [ -d "${MANIFESTS}"/factory-keys/tf-a ] && [ ! -d "conf/factory-keys/tf-a" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/tf-a conf/factory-keys/tf-a
     fi
     # Link custom UEFI development keys and certificates set by the user
-    if [ -d "${MANIFESTS}"/factory-keys/uefi -a ! -d "conf/factory-keys/uefi" ]; then
+    if [ -d "${MANIFESTS}"/factory-keys/uefi ] && [ ! -d "conf/factory-keys/uefi" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/uefi conf/factory-keys/uefi
+    fi
+    # Link default TI K3 RoT keys if not set by the user
+    if [ -d "${MANIFESTS}"/factory-keys/platform ] && [ ! -d "conf/factory-keys/platform" ]; then
+        ln -sf "${MANIFESTS}"/factory-keys/platform conf/factory-keys/platform
     fi
 fi
 
-# Link default iMX HAB4 development keys and certificate if not set by the user
-if [ ! -e "conf/keys/imx_hab4" ]; then
-    ln -sf ${OEROOT}/tools/lmp-tools/security/imx_hab4 conf/keys/imx_hab4
-fi
 ln -sf "${MANIFESTS}"/conf/bblayers.conf conf/bblayers.conf
 ln -sf "${MANIFESTS}"/conf/bblayers-base.inc conf/bblayers-base.inc
 ln -sf "${MANIFESTS}"/conf/bblayers-bsp.inc conf/bblayers-bsp.inc
@@ -272,6 +276,15 @@ INHERIT += "buildstats buildstats-summary"
 INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 EOF
+
+# LMP_VERSION_CACHE was required in some other places on CI so
+# we need to proper check for the existence of LMP_VERSION,
+# which is only available on CI, to safely remove the LMP_VERSION_CACHE
+# on local builds
+if [ ! -v LMP_VERSION ]; then
+    # we don't need this anymore
+    unset LMP_VERSION_CACHE
+fi
 
 if [ ! -e conf/site.conf ]; then
     cat > conf/site.conf <<_EOF


### PR DESCRIPTION
Copied files from LmP v93 release tag in
https://github.com/foundriesio/lmp-manifest

Updated meta-edge to the latest.

Instructions for moving to a newer release of LmP are in https://izumanetworks.atlassian.net/wiki/spaces/IZUMA/pages/83656711/Updating+the+LmP+release+in+manifest-edge