### PR TITLE
Update to LmP 94.1

### DIFF
--- a/conf/keys/cfs/cfs-dev.pub
+++ b/conf/keys/cfs/cfs-dev.pub
@@ -1,0 +1,1 @@
+KQwl5q4hQjwQxu+BYfm4GpFkdgdP2qG19KOmuv67xjM=

--- a/conf/keys/cfs/cfs-dev.sec
+++ b/conf/keys/cfs/cfs-dev.sec
@@ -1,0 +1,2 @@
+Ga5I1u55+hH9kNKLFzztqBpKL0uI/IoAOg0jhwAwAWIpDCXmriFCPBDG74Fh+bgakWR2B0/aobX0
+o6a6/rvGMw==

--- a/conf/local.conf
+++ b/conf/local.conf
@@ -110,6 +110,13 @@ STM32_ROT_KEY_PATH ??= "${TOPDIR}/../tools/lmp-tools/security/stm32mp1/"
 STM32_ROT_KEY_PATH[vardepsexclude] += "TOPDIR"
 STM32_ROT_KEY_PASSWORD ??= "foundries"
 
+#
+# ComposeFS signatures
+#
+CFS_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys/cfs"
+CFS_SIGN_KEYNAME ?= "cfs-dev"
+CFS_SIGN_KEYDIR[vardepsexclude] += "TOPDIR"
+
 # Izuma additions
 #
 

--- a/edge.xml
+++ b/edge.xml
@@ -7,5 +7,5 @@
   <project name="meta-edge"
            path="layers/meta-edge"
            remote="PelionIoT"
-           revision="21cda8b27d74703e9ec7b2c6b178419fb979138c" />
+           revision="6048f0fa32f27d20c0c0117a060996a220865a21" />
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,17 +5,17 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="ee090484cc25d760b8c20f18add17b5eff485b40"/>
+  <project name="bitbake" revision="5a90927f31c4f9fccbe5d9d07d08e6e69485baa8"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1be292cf3484f1a9fb4d7bea3c61cf45cd318264"/>
-  <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="8609de00952d65bb813a48c535c937324efeb18a"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="ab095f7f1ed2615cf8533f4657e9f7f176dfb4de"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="ead509ebe28cb9b588d401c5f254159cd6c5d39a"/>
-  <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="3473dc7c88a16cea2e9a6365e22c2331464078f1"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="88327090d26955a678c6f8bd2585aad4d802f6c4"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="59cc2e75c15f8c6371a4c4a3b7bd2e6c3f145fbc"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3d00fce2f185f5efe0aaa0cf393008a12c4165f3"/>
+  <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="6b10782a1e5760d1dd5d33d561e6367b5f971d8e"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="1a6746a81da4d5bf2e5640fd2fa8f3ea453d40bf"/>
+  <project name="meta-security" path="layers/meta-security" revision="353078bc06c8b471736daab6ed193e30d533d1f1"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="6c4feab2db70cb0c8ddce7e18dc7b851ad475b32"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="8b356b91ed0d4bcab72350a2ddcef880f4fa5c26"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="f6de96c9fa8d0b6c81c32016f342ad93c8940d9e"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,15 +5,15 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="meta-arm" path="layers/meta-arm" revision="b187fb9232ca0a6b5f8f90b4715958546fc41d73"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="0a73d1bdd7713a6189482e463c98043c9939a2a2"/>
-  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="7725256e3859b62f1ff201db7f2cf7026c17656d"/>
+  <project name="meta-arm" path="layers/meta-arm" revision="260e3adc2bf322f52d81c0642c825088a88bb051"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="84be484645cdcc12bc12591874bfebd24cc0c9a6"/>
+  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="8b61684f0b1ba8bacdf3a69d993445e9791d4932"/>
   <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="b0af85c466d96d5f794b125b2542b7a0ea4c91de"/>
-  <project name="meta-yocto" path="layers/meta-yocto" revision="fa70fbb1ebf2a712eebc5b154ce6d754324fb6ef"/>
+  <project name="meta-yocto" path="layers/meta-yocto" revision="c4c74d1e575217ddc4b74759cd83186a70940ef9"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="f8d8efab12040712df32436643621b2756de1f76"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="b7a0792b996b47305c7ec1713621b0e07d314700"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="155218f03ee8222eeb02f11ea9bc41135cf28e38"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="d47fa3649b6155b9c01e06087917ddca341e7cf1"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="1de40ea7ee8ff136dce163b4ad1c1eddf35852a7"/>
 </manifest>

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -200,6 +200,10 @@ if [ -d "${MANIFESTS}"/conf/keys ]; then
     if [ ! -d "conf/keys/platform" ]; then
         ln -sf "${MANIFESTS}"/conf/keys/platform conf/keys/platform
     fi
+    # Link Composefs keys
+    if [ ! -d "conf/keys/cfs" ]; then
+        ln -sf "${MANIFESTS}"/conf/keys/cfs conf/keys/cfs
+    fi
 fi
 
 # Factory specific keys (unique per factory)
@@ -236,6 +240,10 @@ if [ -d "${MANIFESTS}"/factory-keys ]; then
     # Link default TI K3 RoT keys if not set by the user
     if [ -d "${MANIFESTS}"/factory-keys/platform ] && [ ! -d "conf/factory-keys/platform" ]; then
         ln -sf "${MANIFESTS}"/factory-keys/platform conf/factory-keys/platform
+    fi
+    # Link Composefs keys if not set by the user
+    if [ -d "${MANIFESTS}"/factory-keys/cfs ] && [ ! -d "conf/factory-keys/cfs" ]; then
+        ln -sf "${MANIFESTS}"/factory-keys/cfs conf/factory-keys/cfs
     fi
 fi
 


### PR DESCRIPTION
Updated to use the manifests from LmP v94.1
Updated to use v94 version of meta-edge.

NOTE: the new keys are taken directly from the LmP manifest release.

Ref: https://github.com/PelionIoT/meta-edge/pull/40
